### PR TITLE
bower.json: Pull in metadata from upstream

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,20 @@
 {
   "name": "es6-promise",
   "version": "2.2.0",
-  "main": "./promise.js"
+  "description": "A polyfill for ES6-style Promises, tracking rsvp",
+  "authors": [
+    "Stefan Penner <stefan.penner@gmail.com>"
+  ],
+  "main": "./promise.js",
+  "keywords": [
+    "promise"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jakearchibald/ES6-Promises.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jakearchibald/ES6-Promises/issues"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Most of these just make the bower index easier to browse, but some tools
rely on (e.g. the WebJars index will refuse to mirror a bower package
without an open source "license" attribute).